### PR TITLE
Fix: remove branches-ignore for release-automation in workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,11 +5,10 @@ on:
   push:
     branches:
       - main
-    branches-ignore:
-      - release-automation
 
 jobs:
   release:
+    if: github.ref != 'refs/heads/release-automation'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   release:
-    if: github.ref != 'refs/heads/release-automation'
+    if: ${{ github.ref != 'refs/heads/release-automation' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
This pull request updates the release workflow configuration in `.github/workflows/release.yml` to refine the conditions under which the release job runs.

Workflow condition updates:

* Removed the `branches-ignore` configuration for the `release-automation` branch.
* Added an `if` condition to the `release` job to ensure it does not run for the `release-automation` branch.